### PR TITLE
Support changes coming in https://github.com/Naxesss/MapsetParser/pull/12

### DIFF
--- a/Rendering/OverviewRenderer.cs
+++ b/Rendering/OverviewRenderer.cs
@@ -277,10 +277,10 @@ namespace MapsetVerifierBackend.Rendering
         {
             return
                 RenderContainer("Statistics",
-                    RenderBeatmapContent(aBeatmapSet, "Old Star Rating", aBeatmap =>
+                    RenderBeatmapContent(aBeatmapSet, "Approx Star Rating", aBeatmap =>
                     {
-                        // Current star rating calc only supports standard.
-                        if (aBeatmap.generalSettings.mode == Beatmap.Mode.Standard)
+                        // Current star rating calc only supports standard and taiko.
+                        if (aBeatmap.generalSettings.mode == Beatmap.Mode.Standard || aBeatmap.generalSettings.mode == Beatmap.Mode.Taiko)
                             return $"{aBeatmap.starRating:0.##}";
                         else
                             return "N/A";


### PR DESCRIPTION
- Depends on https://github.com/Naxesss/MapsetParser/pull/12

Necessary because `Skill` no longer contains the strain peaks shown in skill charts.