### PR TITLE
Swap Easy and Normal graph colors

### DIFF
--- a/Rendering/SkillChartRenderer.cs
+++ b/Rendering/SkillChartRenderer.cs
@@ -146,8 +146,8 @@ namespace MapsetVerifierBackend.Rendering
 
         private static readonly Dictionary<Beatmap.Difficulty, Color> difficultyColor = new Dictionary<Beatmap.Difficulty, Color>()
         {
-            { Beatmap.Difficulty.Easy,   Color.FromArgb(125, 180,   0) },
-            { Beatmap.Difficulty.Normal, Color.FromArgb( 80, 215, 255) },
+            { Beatmap.Difficulty.Easy,   Color.FromArgb( 80, 215, 255) },
+            { Beatmap.Difficulty.Normal, Color.FromArgb(125, 180,   0) },
             { Beatmap.Difficulty.Hard,   Color.FromArgb(255, 215,   0) },
             { Beatmap.Difficulty.Insane, Color.FromArgb(255,  80, 170) },
             { Beatmap.Difficulty.Expert, Color.FromArgb(125,  80, 255) }


### PR DESCRIPTION
Right now the colors for Easy and Normal are flipped from what they should be, which can be quite confusing when reading the graphs and being used to the known common diff colors. This PR fixes that.

Easy should be blue, and Normal should be green.

Using this page as reference: https://osu.ppy.sh/wiki/en/Beatmap/Difficulty